### PR TITLE
CSP: prevent errors when logged in

### DIFF
--- a/lib/config/csp.php
+++ b/lib/config/csp.php
@@ -5,6 +5,12 @@ add_filter(
 		$csp->upgrade_insecure_requests();
 		$csp->support_google_tag_manager();
 
+		if ( is_user_logged_in() ) {
+			$csp->add_img_src( 'https://secure.gravatar.com' );
+			$csp->add_font_src( 'data:' );
+			$csp->add_img_src( 'data:' );
+		}
+
 		return $csp;
 	}, 10, 1
 );


### PR DESCRIPTION
Prevent CSP from blocking few assets when logged in:
- Gravatar
- data: font-src
- data: image-src